### PR TITLE
Fix calendar runtime crash

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ export default defineConfig([
     ...nextVitals,
     globalIgnores([
         ".next/**",
+        ".vercel/**",
         "out/**",
         "build/**",
         "next-env.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "pg": "^8.11.3",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.2.0",
-        "react-day-picker": "^8.9.1",
+        "react-day-picker": "^9.14.0",
         "react-dom": "^18.3.1",
         "tailwind-merge": "^1.14.0",
         "tailwindcss-animate": "^1.0.7",
@@ -422,6 +422,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",
@@ -2572,6 +2578,15 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tabby_ai/hijri-converter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.8.2.tgz",
@@ -4100,6 +4115,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
       }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
     },
     "node_modules/date-fns-tz": {
       "version": "2.0.0",
@@ -7599,16 +7620,35 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.9.1.tgz",
-      "integrity": "sha512-W0SPApKIsYq+XCtfGeMYDoU0KbsG3wfkYtlw8l+vZp6KoBXGOlhzBUp4tNx1XiwiOZwhfdGOlj7NGSCKGSlg5Q==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "@tabby_ai/hijri-converter": "1.0.5",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
-        "date-fns": "^2.28.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/react-day-picker/node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "pg": "^8.11.3",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.2.0",
-    "react-day-picker": "^8.9.1",
+    "react-day-picker": "^9.14.0",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7",

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import * as React from "react"
-import { ChevronLeft, ChevronRight } from "lucide-react"
 import { DayPicker } from "react-day-picker"
 
 import { cn } from "@/lib/utils"
@@ -52,10 +51,6 @@ function Calendar({
           "aria-selected:bg-accent aria-selected:text-accent-foreground",
         day_hidden: "invisible",
         ...classNames,
-      }}
-      components={{
-        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
       }}
       {...props}
     />


### PR DESCRIPTION
## Summary
- upgrade react-day-picker from v8 to v9 to remove usage of React private internals that crashed in the Next 16 client bundle
- adapt the calendar wrapper to the v9 component API
- ignore generated .vercel output in ESLint

## Verification
- npm audit
- npm run lint
- npx tsc --noEmit
- npm run build
- confirmed fresh .next chunks no longer contain ReactCurrentOwner